### PR TITLE
put newlines where appropriate in Hyde prompt

### DIFF
--- a/src/wandbot/prompts.py
+++ b/src/wandbot/prompts.py
@@ -21,10 +21,11 @@ def load_hyde_prompt(f_name: str = None):
             """Please answer the user's question about the Weights & Biases, W&B or wandb. """
             """Provide a detailed code example with explanations whenever possible. """
             """If the question is not related to Weights & Biases or wandb """
-            """just say "I'm not sure how to respond to that." """
-            """Begin"""
-            """=========="""
-            """Question: {question}"""
+            """just say "I'm not sure how to respond to that."\n"""
+            """\n"""
+            """Begin\n"""
+            """==========\n"""
+            """Question: {question}\n"""
             """Answer:"""
         )
     messages = [


### PR DESCRIPTION
I don't know what this prompt is for, and I'm not a prompt engineer, but I think
```
Please answer the user's question about the Weights & Biases, W&B or wandb. Provide a detailed code example with explanations whenever possible. If the question is not related to Weights & Biases or wandb just say "I'm not sure how to respond to that." Begin==========Question: {question}Answer:
```
is probably not as good as
```
Please answer the user's question about the Weights & Biases, W&B or wandb. Provide a detailed code example with explanations whenever possible. If the question is not related to Weights & Biases or wandb just say "I'm not sure how to respond to that."

Begin
==========
Question: {question}
Answer:
```