### PR TITLE
Add Code to Wrap Chat Class in API

### DIFF
--- a/src/wandbot/api.py
+++ b/src/wandbot/api.py
@@ -2,44 +2,57 @@ from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 from chat import Chat
-
-import os
+# from fake_chat import FakeChat as Chat
 
 # Initialize the FastAPI app
 app = FastAPI()
 
 # Add CORS middleware to the FastAPI app
 app.add_middleware(
-    CORSMiddleware,
-    allow_origins=["*"],
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+  CORSMiddleware,
+  allow_origins=["*"],
+  allow_credentials=True,
+  allow_methods=["*"],
+  allow_headers=["*"],
 )
+
 
 # Create a request model
 class ChatRequest(BaseModel):
-    query: str
+  query: str
+
 
 # Create a response model
 class ChatResponse(BaseModel):
-    response: str
+  response: str
+
+
+class GreetingResponse(BaseModel):
+  greeting: str
+
 
 # Initialize Chat instance as a global variable
 chat = Chat()
 
+
+@app.get("/")
+async def greeting():
+  return GreetingResponse(greeting="Hello User! Welcome to the Wandbot API")
+
+
 # Define the API endpoint
 @app.post("/chat", response_model=ChatResponse)
 async def chat_endpoint(chat_request: ChatRequest) -> ChatResponse:
-    try:
-        print("QUERY: ", chat_request.query)
-        response = chat(chat_request.query)
-        print("RESPONSE: ", response)
-        return ChatResponse(response=response)
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=str(e))
+  try:
+    print("QUERY: ", chat_request.query)
+    response = chat(chat_request.query)
+    print("RESPONSE: ", response)
+    return ChatResponse(response=response)
+  except Exception as e:
+    raise HTTPException(status_code=500, detail=str(e))
+
 
 # Run the FastAPI app using Uvicorn
 if __name__ == "__main__":
-    import uvicorn
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+  import uvicorn
+  uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/wandbot/fake_chat.py
+++ b/src/wandbot/fake_chat.py
@@ -1,0 +1,8 @@
+class FakeChat:
+
+  def __init__(self, ):
+    pass
+
+  def __call__(self, query):
+    response = f"Hello! This is a test. Thanks for the query: {query}"
+    return response + "\n\n"

--- a/src/wandbot/run_gunicorn.sh
+++ b/src/wandbot/run_gunicorn.sh
@@ -1,0 +1,1 @@
+gunicorn main:app -w 4 -k uvicorn.workers.UvicornWorker -b 0.0.0.0:8000 --timeout 600


### PR DESCRIPTION
- This code can be placed in the same directory level as chat.py and be run locally or via repl.it. 
- Added a fake testing chat Class
- Added a bash script to spin up gunicorn workers for running the chat