### PR TITLE
Fix the situation on Replit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+.pythonlibs/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.replit
+++ b/.replit
@@ -1,36 +1,16 @@
-# The command that runs the program. If the interpreter field is set, it will have priority and this run command will do nothing
-run = "bash run.sh"
+run = "poetry lock --no-update && poetry install && bash run.sh"
+entrypoint = "main.py"
+modules = ["python-3.10:v18-20230807-322e88b"]
 
-# The primary language of the repl. There can be others, though!
-language = "python3"
+disableInstallBeforeRun = true
 
-# A list of globs that specify which files and directories should
-# be hidden in the workspace.
-hidden = ["venv", ".config", "**/__pycache__", "**/.mypy_cache", "**/*.pyc"]
+hidden = [".pythonlibs"]
 
-# Specifies which nix channel to use when building the environment.
 [nix]
-channel = "stable-22_11"
-
-[env]
-VIRTUAL_ENV = "${REPL_HOME}/venv"
-PATH = "${VIRTUAL_ENV}/bin"
-PYTHONPATH = "$PYTHONHOME/lib/python3.10:${VIRTUAL_ENV}/lib/python3.10/site-packages"
-REPLIT_POETRY_PYPI_REPOSITORY = "https://package-proxy.replit.com/pypi/"
-MPLBACKEND = "TkAgg"
-POETRY_CACHE_DIR = "${REPL_HOME}/.cache/pypoetry"
-
-# These are the files that need to be preserved when this
-[gitHubImport]
-requiredFiles = [".replit", "replit.nix", ".config", "venv"]
-
-[languages]
-
-[languages.python3]
-pattern = "**/*.py"
-
-[languages.python3.languageServer]
-start = "pylsp"
+channel = "stable-23_05"
 
 [deployment]
 run = ["sh", "-c", "bash run.sh"]
+build = ["sh", "-c", "bash build.sh"]
+deploymentTarget = "gce"
+ignorePorts = true

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,3 @@
+poetry install --all-extras && \
+poetry build && \
+mkdir -p ./data/cache

--- a/run.sh
+++ b/run.sh
@@ -1,10 +1,3 @@
-git pull && \
-python -m pip install -U poetry && \
-poetry install --all-extras --no-cache && \
-poetry build && \
-rm -rf $POETRY_CACHE_DIR/* && \
-echo "Running applications" && \
-mkdir -p ./data/cache && \
-(poetry run uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8000 > api.log 2>&1) & \
-(poetry run python -m wandbot.apps.slack > slack_app.log 2>&1) & \
-(poetry run python -m wandbot.apps.discord > discord_app.log 2>&1)
+(poetry run uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8000) & \
+(poetry run python -m wandbot.apps.slack) & \
+(poetry run python -m wandbot.apps.discord)


### PR DESCRIPTION
## Why

Hey! We saw @parambharat have issues with Replit today. We're working on fixing them in general, but this should unblock wandbot.

## Changes

Most of these are changes by @parambharat, plus some replit specific things. I'll let @parambharat comment on run.sh and build.sh

- `.replit`:
    - now uses a new modules setup which allows for auto updates from Replit and also removes a lot of junk from the file. In the future this can be configured from the UI in a sane way.
    - installs packages then runs `run.sh`
    - added more deployments configuration
- Added `.pythonlibs` to `.gitignore`, it's the equivalent of `node_modules` in node.