### PR TITLE
Zendesk to replit

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,5 @@
-(uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8000) & \
+(uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8080) & \
 (python -m wandbot.apps.slack -l en) & \
 (python -m wandbot.apps.slack -l ja) & \
 (python -m wandbot.apps.discord)
+(python -m wandbot.apps.zendesk)

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
 (uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8000) & \
-# (python -m wandbot.apps.slack -l en) & \
-# (python -m wandbot.apps.slack -l ja) & \
-# (python -m wandbot.apps.discord)
-# (python -m wandbot.apps.zendesk)
+(python -m wandbot.apps.slack -l en) & \
+(python -m wandbot.apps.slack -l ja) & \
+(python -m wandbot.apps.discord)
+(python -m wandbot.apps.zendesk)

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,5 @@
-(uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8080) & \
-(python -m wandbot.apps.slack -l en) & \
-(python -m wandbot.apps.slack -l ja) & \
-(python -m wandbot.apps.discord)
-(python -m wandbot.apps.zendesk)
+(uvicorn wandbot.api.app:app --host="0.0.0.0" --port=8000) & \
+# (python -m wandbot.apps.slack -l en) & \
+# (python -m wandbot.apps.slack -l ja) & \
+# (python -m wandbot.apps.discord)
+# (python -m wandbot.apps.zendesk)

--- a/src/wandbot/apps/zendesk/__main__.py
+++ b/src/wandbot/apps/zendesk/__main__.py
@@ -10,14 +10,14 @@ The system performs the following steps:
  with the response.
 
 This module contains the following classes:
-- ZendeskAIResponseSystem: Handles the interaction with the Zendesk system.
+- zendesk_wandbot_response_system: Handles the interaction with the Zendesk system.
 
 This module contains the following functions:
 - extract_question(ticket): Extracts the question from a given ticket.
 - format_response(response): Formats the response to be sent as a ticket comment.
 
 This module is meant to be run as a script and not imported as a module. When run as a script, it initializes a
-ZendeskAIResponseSystem object and runs it in an event loop.
+zendesk_wandbot_response_system object and runs it in an event loop.
 
 """
 import asyncio
@@ -69,7 +69,7 @@ def format_response(response: str) -> str:
     This function performs the following steps:
     1. Converts the response to a string.
     2. Appends a signature at the end of the response.
-    3. Appends a warning saying that this is wandbot talking in the front
+    3. Appends a warning saying that this is wandbot talking in the front of the reply
 
     Args:
         response (str): The response to be formatted.
@@ -78,12 +78,12 @@ def format_response(response: str) -> str:
         str: The formatted response.
     """
 
-    responseStr = str(response)
-    finalResponse = config.DISCBOTINTRO + responseStr
-    return finalResponse + "\n\n-WandBot 🤖"
+    response_str = str(response)
+    final_response = config.DISCBOTINTRO + response_str
+    return final_response + "\n\n-WandBot 🤖"
 
 
-class ZendeskAIResponseSystem:
+class zendesk_wandbot_response_system:
     """Handles the interaction with the Zendesk system.
 
     This class is responsible for creating and updating tickets in the Zendesk system. It uses the Zenpy client for
@@ -96,7 +96,7 @@ class ZendeskAIResponseSystem:
     """
 
     def __init__(self) -> None:
-        """Initializes the ZendeskAIResponseSystem with the necessary clients.
+        """Initializes the zendesk_wandbot_response_system with the necessary clients.
 
         The Zenpy client is initialized with the user credentials from the configuration. The AsyncAPIClient is
         initialized with the WandBot API URL from the configuration.
@@ -217,10 +217,10 @@ class ZendeskAIResponseSystem:
             None
         """
 
-        # after semLimit number of tickets, have a timeout
-        semLimit = config.MAX_WANDBOT_REQUESTS
+        # after set_limit number of tickets, have a timeout
+        set_limit = config.MAX_WANDBOT_REQUESTS
         logger.info(f"WandBot + zendesk is running")
-        sem = asyncio.Semaphore(semLimit)
+        sem = asyncio.Semaphore(set_limit)
 
         while True:
             await asyncio.sleep(config.INTERVAL_TO_FETCH_TICKETS)
@@ -232,10 +232,10 @@ class ZendeskAIResponseSystem:
             new_tickets = list(self.fetch_new_tickets())
             logger.info(f"New unanswered Zendesk tickets: {new_tickets}")
 
-            # For every semLimit new tickets, extract the question, generate a response, format the response,
+            # For every set_limit new tickets, extract the question, generate a response, format the response,
             # and update the ticket with the response
-            for i in range(0, len(new_tickets), semLimit):
-                batch = new_tickets[i : i + semLimit]
+            for i in range(0, len(new_tickets), set_limit):
+                batch = new_tickets[i : i + set_limit]
                 for ticket in batch:
                     async with sem:
                         question = extract_question(ticket)
@@ -245,7 +245,7 @@ class ZendeskAIResponseSystem:
                         self.update_ticket(ticket, formatted_response)
 
                 # Timeout after a certain amount of tickets, 5 in this case
-                if i + semLimit < len(new_tickets):
+                if i + set_limit < len(new_tickets):
                     await asyncio.sleep(config.REQUEST_INTERVAL)
 
             if len(new_tickets) > 0:
@@ -253,5 +253,5 @@ class ZendeskAIResponseSystem:
 
 
 if __name__ == "__main__":
-    zd = ZendeskAIResponseSystem()
+    zd = zendesk_wandbot_response_system()
     asyncio.run(zd.run())

--- a/src/wandbot/apps/zendesk/__main__.py
+++ b/src/wandbot/apps/zendesk/__main__.py
@@ -10,14 +10,14 @@ The system performs the following steps:
  with the response.
 
 This module contains the following classes:
-- zendesk_wandbot_response_system: Handles the interaction with the Zendesk system.
+- ZendeskWandBotResponseSystem: Handles the interaction with the Zendesk system.
 
 This module contains the following functions:
 - extract_question(ticket): Extracts the question from a given ticket.
 - format_response(response): Formats the response to be sent as a ticket comment.
 
 This module is meant to be run as a script and not imported as a module. When run as a script, it initializes a
-zendesk_wandbot_response_system object and runs it in an event loop.
+ZendeskWandBotResponseSystem object and runs it in an event loop.
 
 """
 import asyncio
@@ -41,7 +41,7 @@ def extract_question(ticket: Ticket) -> str:
 
     This function performs the following steps:
     1. Extracts the description from the ticket.
-    2. Chooses what type of ticket we are looking at, and then extracts the ticket depending on the ticket type
+    2. Chooses what type of ticket we are looking at, and then extracts the ticket depending on the ticket type.
 
     Args:
         ticket (Ticket): The ticket object from which the question is to be extracted.
@@ -49,14 +49,11 @@ def extract_question(ticket: Ticket) -> str:
     Returns:
         str: The extracted question from the ticket's description.
     """
-
     description = ticket.description
     if "forum" in ticket.tags:
         return discourse_ext(description)
-
     elif "zopim_offline_message" in ticket.tags:
         return offline_msg_ext(description)
-
     elif "add_cc_note" in ticket.tags:
         return email_msg_ext(description)
 
@@ -69,7 +66,7 @@ def format_response(response: str) -> str:
     This function performs the following steps:
     1. Converts the response to a string.
     2. Appends a signature at the end of the response.
-    3. Appends a warning saying that this is wandbot talking in the front of the reply
+    3. Appends a warning saying that this is wandbot talking in the front of the reply.
 
     Args:
         response (str): The response to be formatted.
@@ -77,13 +74,12 @@ def format_response(response: str) -> str:
     Returns:
         str: The formatted response.
     """
-
     response_str = str(response)
     final_response = config.DISCBOTINTRO + response_str
-    return final_response + "\n\n-WandBot 🤖"
+    return f"{final_response}\n\n-WandBot 🤖"
 
 
-class zendesk_wandbot_response_system:
+class ZendeskWandBotResponseSystem:
     """Handles the interaction with the Zendesk system.
 
     This class is responsible for creating and updating tickets in the Zendesk system. It uses the Zenpy client for
@@ -94,14 +90,12 @@ class zendesk_wandbot_response_system:
         api_client (AsyncAPIClient): The client for interacting with the WandBot API.
         semaphore (Semaphore): Use semaphore to control how many api calls to wandbot we make
     """
-
     def __init__(self) -> None:
-        """Initializes the zendesk_wandbot_response_system with the necessary clients.
+        """Initializes the ZendeskWandBotResponseSystem with the necessary clients.
 
         The Zenpy client is initialized with the user credentials from the configuration. The AsyncAPIClient is
         initialized with the WandBot API URL from the configuration.
         """
-
         self.user_creds = {
             "email": config.ZENDESK_EMAIL,
             "password": config.ZENDESK_PASSWORD,
@@ -117,21 +111,21 @@ class zendesk_wandbot_response_system:
         """Fetches new tickets from the Zendesk system.
 
         This method uses the Zenpy client to fetch new tickets from the Zendesk system. It filters the fetched
-        tickets based on specific requirements. The tickets are filtered if they have the tags "forum", "zopim_offline_message" and do not have
-        the tag "answered_by_bot", "zopim_chat", "picked_up_by_bot".
+        tickets based on specific requirements. The tickets are filtered if they have the tags "forum",
+        "zopim_offline_message" and do not have the tag "answered_by_bot", "zopim_chat", "picked_up_by_bot".
 
         Returns:
             list: A list of filtered tickets that are new and have not been answered by the bot.
         """
-
         exclude_tags = ["answered_by_bot", "zopim_chat", "picked_up_by_bot"]
         new_tickets = self.zenpy_client.search(
             type="ticket",
             status="new",
             tags=["forum", "zopim_offline_message"],
-            minus=["tags:{}".format(tag) for tag in exclude_tags],
+            minus=[f"tags:{tag}" for tag in exclude_tags],
         )
         return new_tickets
+
 
     async def generate_response(self, question: str) -> str:
         """Generates a response to a given question.
@@ -253,5 +247,5 @@ class zendesk_wandbot_response_system:
 
 
 if __name__ == "__main__":
-    zd = zendesk_wandbot_response_system()
+    zd = ZendeskWandBotResponseSystem()
     asyncio.run(zd.run())

--- a/src/wandbot/apps/zendesk/__main__.py
+++ b/src/wandbot/apps/zendesk/__main__.py
@@ -27,13 +27,13 @@ from zenpy import Zenpy
 from zenpy.lib.api_objects import Comment, Ticket
 
 from wandbot.api.client import AsyncAPIClient
-from wandbot.apps.zendesk.config import ZendeskAppConfig
+from wandbot.apps.zendesk.config import zendesk_app_config
 from wandbot.utils import get_logger
 from wandbot.apps.zendesk.extract_by_type import *
 
 
 logger = get_logger(__name__)
-config = ZendeskAppConfig()
+config = zendesk_app_config()
 
 
 def extract_question(ticket: Ticket) -> str:

--- a/src/wandbot/apps/zendesk/__main__.py
+++ b/src/wandbot/apps/zendesk/__main__.py
@@ -69,6 +69,7 @@ def format_response(response: str) -> str:
     This function performs the following steps:
     1. Converts the response to a string.
     2. Appends a signature at the end of the response.
+    3. Appends a warning saying that this is wandbot talking in the front
 
     Args:
         response (str): The response to be formatted.

--- a/src/wandbot/apps/zendesk/config.py
+++ b/src/wandbot/apps/zendesk/config.py
@@ -4,7 +4,7 @@ from pydantic_settings import BaseSettings, SettingsConfigDict
 ZDGROUPID = "360016040851"
 
 
-class ZendeskAppConfig(BaseSettings):
+class zendesk_app_config(BaseSettings):
     DISCBOTINTRO: str = (
         "Thank you for reaching out to W&B Technical Support!\n\n"
     f"This is an automated reply from our support bot designed to assist you with your WandB-related queries.\n"

--- a/src/wandbot/apps/zendesk/config.py
+++ b/src/wandbot/apps/zendesk/config.py
@@ -5,11 +5,20 @@ ZDGROUPID = "360016040851"
 
 
 class ZendeskAppConfig(BaseSettings):
+    DISCBOTINTRO: str = (
+        "Thank you for reaching out to W&B Technical Support!\n\n"
+    f"This is an automated reply from our support bot designed to assist you with your WandB-related queries.\n"
+    f"If you find the solution unsatisfactory or have additional questions, we encourage you to contact our support team at support@wandb.com, or continue replying in this thread\n\n"
+    )
+    
     ZENDESK_EMAIL: str = (Field(..., env="ZENDESK_EMAIL"),)
     ZENDESK_PASSWORD: str = (Field(..., env="ZENDESK_PASSWORD"),)
     ZENDESK_SUBDOMAIN: str = (Field(..., env="ZENDESK_SUBDOMAIN"),)
     ZDGROUPID: str = ZDGROUPID
     WANDBOT_API_URL: AnyHttpUrl = Field(..., env="WANDBOT_API_URL")
+    MAX_WANDBOT_REQUESTS: int = 5
+    REQUEST_INTERVAL: int = 60
+    INTERVAL_TO_FETCH_TICKETS: int = 600
     include_sources: bool = True
     bot_language: str = "en"
 

--- a/src/wandbot/apps/zendesk/extract_by_type.py
+++ b/src/wandbot/apps/zendesk/extract_by_type.py
@@ -1,13 +1,14 @@
-def discourseExt(description) -> str:
-    question = description.lower().replace('\n', ' ').replace('\r', '')
-    question = question.replace('[discourse post]','')
-    question = question[:4095]
+def discourse_ext(description) -> str:
+    question = description.lower().replace("\n", " ").replace("\r", "")
+    question = question.replace("[discourse post]", "")
     return question
 
-def offlineMessageExt(description) -> str:
+
+def offline_msg_ext(description) -> str:
     question = description.partition("Offline transcript:")[2]
     return question
 
-def emailMsgExt(description) -> str:
+
+def email_msg_ext(description) -> str:
     # its already clean but returning this for consistency
     return description

--- a/src/wandbot/apps/zendesk/extract_by_type.py
+++ b/src/wandbot/apps/zendesk/extract_by_type.py
@@ -1,0 +1,13 @@
+def discourseExt(description) -> str:
+    question = description.lower().replace('\n', ' ').replace('\r', '')
+    question = question.replace('[discourse post]','')
+    question = question[:4095]
+    return question
+
+def offlineMessageExt(description) -> str:
+    question = description.partition("Offline transcript:")[2]
+    return question
+
+def emailMsgExt(description) -> str:
+    # its already clean but returning this for consistency
+    return description


### PR DESCRIPTION
Changes: 
- Added zd integration to run.sh
- Added a new file to the `zendesk` directory `extract_by_type.py` which has different question extraction methods depending on what type of ticket it is. 
- Made the tickets to get pulled every 10 minutes
- Made every ten minutes we relogin to the Zenpy API, because it times out if it has been more than 3 minutes
- Got the tickets to private answer the Offline Chat messages that come in when chat isn't on after certain hours. 
------------------

Tested by: 
- Creating multiple dummy tickets in Zendesk with dummy questions, then having the script pull them up, process them and reply to the dummy questions.
- Was tested with zd tickets with different tags such as `forum` - which is usually used for discourse tickets and `zopim_offline_message` - these tickets are sent to us when the chat is down during the night time. Making sure tagging worked was essential to get the script to answer specific tickets - Discourse and Offline Chat Tickets. 
- Tested on different numbers of tickets at the same time, anywhere from 1 to 12 including real free-user tickets and the dummy tickets that would be answered at the same time. 
- After Semaphore was added to limit 5 api calls per minute, tested to make sure the script works with more and less than 5 tickets which are needed to be answered. This was done by create multiple dummy tickets along with the tickets that already have been answered and made the zd script answer those tickets in the count of 5s every minute. 

- Have been running the script in github workspaces without an issue. 