### PR TITLE
feat: integrate weave with evaluation pipeline and experiments with finetuning

### DIFF
--- a/src/wandbot/api/routers/chat.py
+++ b/src/wandbot/api/routers/chat.py
@@ -8,7 +8,6 @@ from wandbot.utils import get_logger
 logger = get_logger(__name__)
 
 chat_config = ChatConfig()
-logger.info(f"Chat config: {chat_config}")
 chat: Chat | None = None
 
 router = APIRouter(

--- a/src/wandbot/evaluation/weave_eval/log_eval_data.py
+++ b/src/wandbot/evaluation/weave_eval/log_eval_data.py
@@ -1,0 +1,41 @@
+import os
+os.environ["WANDB_ENTITY"] = "wandbot"
+
+import wandb
+import weave
+import pandas as pd
+from weave import Dataset
+
+from wandbot.evaluation.config import EvalConfig
+
+config = EvalConfig()
+
+wandb_project = config.wandb_project
+wandb_entity = config.wandb_entity
+
+eval_artifact = wandb.Api().artifact(config.eval_artifact)
+eval_artifact_dir = eval_artifact.download(root=config.eval_artifact_root)
+
+df = pd.read_json(
+    f"{eval_artifact_dir}/{config.eval_annotations_file}",
+    lines=True,
+    orient="records",
+)
+df.insert(0, "id", df.index)
+
+correct_df = df[
+    (df["is_wandb_query"] == "YES") & (df["correctness"] == "correct")
+]
+
+data_rows = correct_df.to_dict('records')
+
+weave.init(wandb_project)
+
+# Create a dataset
+dataset = Dataset(
+    name='wandbot_eval_data',
+    rows=data_rows,
+)
+
+# Publish the dataset
+weave.publish(dataset)

--- a/src/wandbot/evaluation/weave_eval/main.py
+++ b/src/wandbot/evaluation/weave_eval/main.py
@@ -1,0 +1,102 @@
+import os
+os.environ["WANDB_ENTITY"] = "wandbot"
+
+import time
+import json
+import httpx
+import wandb
+import weave
+import asyncio
+import pandas as pd
+from weave import Evaluation
+from llama_index.llms.openai import OpenAI
+
+from wandbot.evaluation.config import EvalConfig
+from wandbot.utils import get_logger
+
+from wandbot.evaluation.eval.correctness import (
+    CORRECTNESS_EVAL_TEMPLATE,
+    WandbCorrectnessEvaluator,
+)
+
+logger = get_logger(__name__)
+config = EvalConfig()
+
+correctness_evaluator = WandbCorrectnessEvaluator(
+    llm=OpenAI(config.eval_judge_model),
+    eval_template=CORRECTNESS_EVAL_TEMPLATE,
+)
+
+wandb_project = config.wandb_project
+wandb_entity = config.wandb_entity
+
+weave.init("weave_test_eval")
+
+
+@weave.op()
+async def get_answer(question: str, application: str = "api-eval") -> str:
+    url = "http://0.0.0.0:8000/chat/query"
+    payload = {
+        "question": question,
+        "application": application,
+        "language": "en",
+    }
+    async with httpx.AsyncClient(timeout=200.0) as client:
+        response = await client.post(url, json=payload)
+        response_json = response.json()
+    return json.dumps(response_json)
+
+
+@weave.op()
+async def get_eval_record(row_str: str) -> str:
+    row = json.loads(row_str)
+    response = await get_answer(row["question"])
+    response = json.loads(response)
+    response["ground_truths"] = row["answer"]
+    response["reference_notes"] = row["notes"]
+    response["contexts"] = response["source_documents"]
+    response = json.dumps(response)
+    return response
+
+
+@weave.op()
+def parse_answer_eval(metric: str, row):
+    print("result is: ", row.get("passing"), type(row.get("passing")))
+    return {
+        f"{metric}_result": True if row.get("passing") is True else False,
+    }
+
+
+@weave.op()
+async def get_answer_correctness(model_output: str) -> str:
+    row = json.loads(model_output)
+    result = await correctness_evaluator.aevaluate(
+        query=row["question"],
+        response=row["answer"],
+        reference=row["ground_truths"],
+        contexts=row["contexts"],
+        reference_notes=row["reference_notes"],
+    )
+    # result = parse_answer_eval("answer_correctness", result.dict())
+    # result = json.dumps(result)
+    return {"answer_correctness": result.dict()["passing"]}
+    # return result
+
+
+dataset_ref = weave.ref(
+    "weave:///wandbot/wandbot-eval/object/wandbot_eval_data:eCQQ0GjM077wi4ykTWYhLPRpuGIaXbMwUGEB7IyHlFU"
+).get()
+question_rows = dataset_ref.rows
+question_rows = [
+    {
+        "row_str": json.dumps(row)
+    } for row in question_rows
+]
+logger.info("Number of evaluation samples: %s", len(question_rows))
+
+evaluation = Evaluation(
+    dataset=question_rows, scorers=[get_answer_correctness]
+)
+
+if __name__ == "__main__":
+    asyncio.run(evaluation.evaluate(get_eval_record))

--- a/src/wandbot/evaluation/weave_eval/weave_correctness.py
+++ b/src/wandbot/evaluation/weave_eval/weave_correctness.py
@@ -1,0 +1,127 @@
+import asyncio
+from typing import Any, Optional, Sequence
+
+import regex as re
+from llama_index.core.evaluation import CorrectnessEvaluator, EvaluationResult
+
+from wandbot.evaluation.eval.utils import (
+    make_eval_template,
+    safe_parse_eval_response,
+)
+
+import wandb
+import weave
+
+SYSTEM_TEMPLATE = """You are a Weight & Biases support expert tasked with evaluating the correctness of answers to questions asked by users to a a technical support chatbot.
+
+You are given the following information:
+- a user query,
+- the documentation used to generate the answer
+- a reference answer
+- the reason why the reference answer is correct, and
+- a generated answer.
+
+
+Your job is to judge the relevance and correctness of the generated answer.
+- Consider whether the answer addresses all aspects of the question.
+- The generated answer must provide only correct information according to the documentation.
+- Compare the generated answer to the reference answer for completeness and correctness.
+- Output a score and a decision that represents a holistic evaluation of the generated answer.
+- You must return your response only in the below mentioned format. Do not return answers in any other format.
+
+Follow these guidelines for scoring:
+- Your score has to be between 1 and 3, where 1 is the worst and 3 is the best.
+- If the generated answer is not correct in comparison to the reference, you should give a score of 1.
+- If the generated answer is correct in comparison to the reference but contains mistakes, you should give a score of 2.
+- If the generated answer is correct in comparision to the reference and completely answer's the user's query, you should give a score of 3.
+
+Output your final verdict by strictly following JSON format:
+{{
+    "reason": <<Provide a brief explanation for your decision here>>,
+    "score": <<Provide a score as per the above guidelines>>,
+    "decision": <<Provide your final decision here, either 'correct', or 'incorrect'>>
+
+}}
+
+Example Response 1:
+{{
+    "reason": "The generated answer has the exact details as the reference answer and completely answer's the user's query.",
+    "score": 3,
+    "decision": "correct"
+}}
+
+Example Response 2:
+{{
+    "reason": "The generated answer doesn't match the reference answer, and deviates from the documentation provided",
+    "score": 1,
+    "decision": "incorrect"
+}}
+
+Example Response 3:
+{{
+    "reason": "The generated answer follows the same steps as the reference answer. However, it includes assumptions about methods that are not mentioned in the documentation.",
+    "score": 2,
+    "decision": "incorrect"
+}}
+"""
+
+
+USER_TEMPLATE = """
+## User Query
+{query}
+
+## Documentation
+{context_str}
+
+## Reference Answer
+{reference_answer}
+
+## Reference Correctness Reason
+{reference_notes}
+
+## Generated Answer
+{generated_answer}
+"""
+
+CORRECTNESS_EVAL_TEMPLATE = make_eval_template(SYSTEM_TEMPLATE, USER_TEMPLATE)
+
+
+class WandbCorrectnessEvaluator(CorrectnessEvaluator):
+    @weave.op()
+    async def aevaluate(
+        self,
+        query: Optional[str] = None,
+        response: Optional[str] = None,
+        contexts: Optional[Sequence[str]] = None,
+        reference: Optional[str] = None,
+        sleep_time_in_seconds: int = 0,
+        **kwargs: Any,
+    ) -> EvaluationResult:
+        await asyncio.sleep(sleep_time_in_seconds)
+
+        if query is None or response is None or reference is None:
+            print(query, response, reference, flush=True)
+            raise ValueError("query, response, and reference must be provided")
+
+        eval_response = await self._llm.apredict(
+            prompt=self._eval_template,
+            query=query,
+            generated_answer=response,
+            reference_answer=reference,
+            context_str=re.sub(
+                "\n+", "\n", "\n---\n".join(contexts) if contexts else ""
+            ),
+            reference_notes=kwargs.get("reference_notes", ""),
+        )
+
+        passing, reasoning, score = await safe_parse_eval_response(
+            eval_response, "correct"
+        )
+
+        return EvaluationResult(
+            query=query,
+            response=response,
+            passing=passing,
+            score=score,
+            feedback=reasoning,
+        )


### PR DESCRIPTION
- [x] Adds W&B Weave Evaluation in our evaluation pipeline. 
- [x] Adds LiteLLM to easily configure embedding models.
- [ ] Use HF Inference Endpoint to host embedding models and use it in the pipeline.
- [ ] Generate dataset for embedding finetuning (synthetic)
- [ ] Evaluation of performance with OpenAI embedding, OS embedding and fine-tuned OS embedding
- [ ] End-to-end evaluation with new embeddings with weave eval.