### PR TITLE
hotfix: fix sqlalchemy table creation issue due to moved import

### DIFF
--- a/src/wandbot/api/routers/database.py
+++ b/src/wandbot/api/routers/database.py
@@ -1,11 +1,8 @@
+import wandb
 from fastapi import APIRouter
 from starlette import status
 from starlette.responses import Response
-
-import wandb
 from wandbot.database.client import DatabaseClient
-from wandbot.database.database import engine
-from wandbot.database.models import Base
 from wandbot.database.schemas import (
     ChatThread,
     ChatThreadCreate,
@@ -18,7 +15,6 @@ from wandbot.utils import get_logger
 
 logger = get_logger(__name__)
 
-Base.metadata.create_all(bind=engine)
 
 db_client: DatabaseClient | None = None
 

--- a/src/wandbot/api/routers/database.py
+++ b/src/wandbot/api/routers/database.py
@@ -1,7 +1,8 @@
-import wandb
 from fastapi import APIRouter
 from starlette import status
 from starlette.responses import Response
+
+import wandb
 from wandbot.database.client import DatabaseClient
 from wandbot.database.schemas import (
     ChatThread,

--- a/src/wandbot/database/database.py
+++ b/src/wandbot/database/database.py
@@ -12,6 +12,7 @@ Typical usage example:
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from wandbot.database.config import DataBaseConfig
 from wandbot.database.models import Base
 

--- a/src/wandbot/database/database.py
+++ b/src/wandbot/database/database.py
@@ -12,8 +12,8 @@ Typical usage example:
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-
 from wandbot.database.config import DataBaseConfig
+from wandbot.database.models import Base
 
 db_config = DataBaseConfig()
 
@@ -21,3 +21,4 @@ engine = create_engine(
     db_config.SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
This PR fixes the SQLite table creation issue that causes split deployments to fail. It moves the import to a single module so that tables are only created once, fixing the issue.