### PR TITLE
fix: delay app startup and move sql db creation

### DIFF
--- a/src/wandbot/api/app.py
+++ b/src/wandbot/api/app.py
@@ -34,9 +34,10 @@ from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 
 import pandas as pd
-import wandb
 import weave
 from fastapi import BackgroundTasks, FastAPI
+
+import wandb
 from wandbot.api.routers import chat as chat_router
 from wandbot.api.routers import database as database_router
 from wandbot.api.routers import retrieve as retrieve_router

--- a/src/wandbot/apps/utils.py
+++ b/src/wandbot/apps/utils.py
@@ -16,7 +16,6 @@ from collections import OrderedDict
 from typing import Any, List
 
 from pydantic_settings import BaseSettings
-
 from wandbot.api.routers.chat import APIQueryResponse
 
 
@@ -62,7 +61,7 @@ def format_response(
             sources_list = deduplicate(
                 [
                     item
-                    for item in response.sources.split(",")
+                    for item in response.sources.split("\n")
                     if item.strip().startswith("http")
                 ]
             )
@@ -72,13 +71,13 @@ def format_response(
                     result = (
                         f"{result}\n\n*参考文献*\n\n>"
                         + "\n> ".join(sources_list[:items])
-                        + "\n\n"
+                        + "\n"
                     )
                 else:
                     result = (
                         f"{result}\n\n*References*\n\n>"
                         + "\n> ".join(sources_list[:items])
-                        + "\n\n"
+                        + "\n"
                     )
         if outro_message:
             result = f"{result}\n\n{outro_message}"

--- a/src/wandbot/apps/utils.py
+++ b/src/wandbot/apps/utils.py
@@ -16,6 +16,7 @@ from collections import OrderedDict
 from typing import Any, List
 
 from pydantic_settings import BaseSettings
+
 from wandbot.api.routers.chat import APIQueryResponse
 
 

--- a/src/wandbot/database/database.py
+++ b/src/wandbot/database/database.py
@@ -12,6 +12,7 @@ Typical usage example:
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+
 from wandbot.database.config import DataBaseConfig
 
 db_config = DataBaseConfig()

--- a/src/wandbot/database/database.py
+++ b/src/wandbot/database/database.py
@@ -12,9 +12,7 @@ Typical usage example:
 
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
-
 from wandbot.database.config import DataBaseConfig
-from wandbot.database.models import Base
 
 db_config = DataBaseConfig()
 
@@ -22,4 +20,3 @@ engine = create_engine(
     db_config.SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
-Base.metadata.create_all(bind=engine)


### PR DESCRIPTION
This PR makes minor fixes to delay app start-up and move the DB creation to start-up to get it working with the split. 
It also adds a minor fix to the response formatting of Slack and Discord references. 