### PR TITLE
Implement streaming endpoint

### DIFF
--- a/src/wandbot/chat/rag.py
+++ b/src/wandbot/chat/rag.py
@@ -142,3 +142,45 @@ class RAGPipeline:
          self, question: str, chat_history: List[Tuple[str, str]] | None = None
      ) -> RAGPipelineOutput:
         return run_sync(self.__acall__(question, chat_history))
+
+    async def astream(
+        self, question: str, chat_history: List[Tuple[str, str]] | None = None
+    ) -> None:
+        """Stream tokens from the response synthesizer."""
+        if chat_history is None:
+            chat_history = []
+
+        enhanced_query = await self.query_enhancer({"query": question, "chat_history": chat_history})
+        retrieval_result = await self.retrieval_engine.__acall__(enhanced_query)
+
+        async for token in self.response_synthesizer.stream(retrieval_result):
+            yield token
+
+        response = self.response_synthesizer.stream_output
+
+        self.stream_result = RAGPipelineOutput(
+            question=enhanced_query["standalone_query"],
+            answer=response["response"],
+            sources="\n".join(
+                [doc.metadata["source"] for doc in retrieval_result.documents]
+            ),
+            source_documents=response["context_str"],
+            system_prompt=response["response_prompt"],
+            model=response["response_model"],
+            total_tokens=0,
+            prompt_tokens=0,
+            completion_tokens=0,
+            time_taken=0,
+            start_time=datetime.datetime.now(),
+            end_time=datetime.datetime.now(),
+            api_call_statuses={
+                "web_search_success": retrieval_result.retrieval_info["api_statuses"]["web_search_api"].success,
+                "reranker_api_error_info": retrieval_result.retrieval_info["api_statuses"]["reranker_api"].error_info,
+                "reranker_api_success": retrieval_result.retrieval_info["api_statuses"]["reranker_api"].success,
+                "query_enhancer_llm_api_error_info": enhanced_query.get("api_statuses", {}).get("query_enhancer_llm_api", {}).error_info if enhanced_query.get("api_statuses") else None,
+                "query_enhancer_llm_api_success": enhanced_query.get("api_statuses", {}).get("query_enhancer_llm_api", {}).success if enhanced_query.get("api_statuses") else False,
+                "embedding_api_error_info": retrieval_result.retrieval_info["api_statuses"]["embedding_api"].error_info,
+                "embedding_api_success": retrieval_result.retrieval_info["api_statuses"]["embedding_api"].success,
+            },
+            response_synthesis_llm_messages=response.get("response_synthesis_llm_messages"),
+        )

--- a/src/wandbot/chat/schemas.py
+++ b/src/wandbot/chat/schemas.py
@@ -46,6 +46,7 @@ class ChatRequest(BaseModel):
     chat_history: List[QuestionAnswer] | None = None
     application: str | None = None
     language: str = "en"
+    stream: bool = False
 
 
 class ChatResponse(BaseModel):

--- a/src/wandbot/rag/response_synthesis.py
+++ b/src/wandbot/rag/response_synthesis.py
@@ -227,6 +227,36 @@ class ResponseSynthesizer:
             }
         }
 
+    async def stream(self, inputs: RetrievalResult):
+        """Stream response tokens while capturing the final result."""
+        formatted_input = self._format_input(inputs)
+        messages = self.get_messages(formatted_input)
+
+        result = ""
+        used_model = self.model
+        try:
+            async for token in self.model.stream(messages=messages):
+                result += token
+                yield token
+        except Exception as e:
+            logger.warning(f"Primary Response Synthesizer model failed, trying fallback: {str(e)}")
+            used_model = self.fallback_model
+            async for token in self.fallback_model.stream(messages=messages):
+                result += token
+                yield token
+
+        self.stream_output = {
+            "query_str": formatted_input["query_str"],
+            "context_str": formatted_input["context_str"],
+            "response": result,
+            "response_model": used_model.model_name,
+            "response_synthesis_llm_messages": messages,
+            "response_prompt": RESPONSE_SYNTHESIS_SYSTEM_PROMPT,
+            "api_statuses": {
+                "response_synthesis_llm_api": None
+            },
+        }
+
     def _format_input(self, inputs: RetrievalResult) -> Dict[str, str]:
         """Format the input data for the prompt template."""
         return {

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,0 +1,38 @@
+import pytest
+
+from wandbot.rag.response_synthesis import ResponseSynthesizer
+from wandbot.schema.document import Document
+from wandbot.schema.retrieval import RetrievalResult
+
+
+async def fake_stream(*args, **kwargs):
+    for tok in ["hello ", "world"]:
+        yield tok
+
+
+@pytest.mark.asyncio
+async def test_streaming_response():
+    synth = ResponseSynthesizer(
+        primary_provider="openai",
+        primary_model_name="dummy",
+        primary_temperature=0,
+        fallback_provider="openai",
+        fallback_model_name="dummy",
+        fallback_temperature=0,
+        max_retries=1,
+    )
+
+    synth.model.stream = fake_stream  # type: ignore
+    synth.get_messages = lambda x: []
+
+    retrieval = RetrievalResult(
+        documents=[Document(page_content="doc", metadata={"source": "s"})],
+        retrieval_info={"query": "q", "language": "en", "intents": [], "sub_queries": []},
+    )
+
+    tokens = []
+    async for token in synth.stream(retrieval):
+        tokens.append(token)
+
+    assert "".join(tokens) == "hello world"
+    assert synth.stream_output["response"] == "hello world"


### PR DESCRIPTION
## Summary
- support streaming in ChatRequest
- add StreamingResponse endpoint
- connect new `astream` pipeline to LLM streaming
- provide LLM streaming implementations
- test streaming via mock

## Testing
- `pytest -k test_streaming_response tests/test_stream.py` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_686b7f40cdf4832ba2d6ca8a1b3a7570

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for streaming chat responses, allowing users to receive answers incrementally as they are generated.
  * Introduced a new option to enable or disable streaming in chat requests.

* **Bug Fixes**
  * Improved handling of language translation during streaming for Japanese queries.

* **Tests**
  * Added tests to verify the streaming response functionality in chat interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->